### PR TITLE
Add LLDB build support to update.py

### DIFF
--- a/Ghidra.app/Contents/MacOS/ghidra
+++ b/Ghidra.app/Contents/MacOS/ghidra
@@ -16,6 +16,7 @@ SCRIPT_FILE="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || grea
 SCRIPT_DIR="${SCRIPT_FILE%/*}"
 
 RESOURCES_DIR="${SCRIPT_DIR}/../Resources"
+MACOS_DIR="${SCRIPT_DIR}/"
 SCRIPT_DIR=$(ls -1 ${RESOURCES_DIR}/*/ghidraRun | while read GHIDRA_RUN_PATH; do echo ${GHIDRA_RUN_PATH%/ghidraRun}; done | sort -V | tail -n1)
 
 GHIDRA_PATCH_DIR="${SCRIPT_DIR%/*}_patch"
@@ -28,4 +29,4 @@ fi
 if [ -d "${RESOURCES_DIR}/jdk" ]; then
 	export JAVA_HOME=${RESOURCES_DIR}/jdk
 fi
-PATH="${RESOURCES_DIR}/jdk/bin:${PATH}" "${SCRIPT_DIR}"/support/launch.sh fg Ghidra "${MAXMEM}" "" ghidra.GhidraRun
+PATH="${MACOS_DIR}:${RESOURCES_DIR}/jdk/bin:${PATH}" "${SCRIPT_DIR}"/support/launch.sh fg Ghidra "${MAXMEM}" "" ghidra.GhidraRun


### PR DESCRIPTION
This pull request adds an optional step to build a Ghidra Debugger compatible LLDB into the app bundle.

This will need some special entitlements to function as a local debugger, but the idea is to use this with lldb's
remote debugger capability to avoid entitling this debugger. A user would use Ghidra to connect to a remote
`debugserver` or lldb to debug their application.

- Clone llvm-project to the download cache
- Compile lldb with ninja
- copy binaries into the Ghidra bundle
- update launch parameters to use our lldb

This fixed #5 