### PR TITLE
Add instructions for embedding OpenJDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Ghidra.dmg
 *.zip
 *.tar.gz
 .DS_Store
+venv*/
+*.dmg

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ pip3 install -r requirements.txt
 open Ghidra*.dmg
 ```
 
+### Embedding OpenJDK
+
+To embed OpenJDK into the bundle, first download the appropriate [OpenJDK](https://jdk.java.net/19/) for your platform and then use the following command:
+
+```bash
+pip3 install -r requirements.txt
+./update.py --dmg --jdk ~/Downloads/jdk-19.0.2.jdk/Contents/Home
+```
+
 ### Experimental Python3 (and more!) with Graal and Ghidraal
 
 Building a bundle with:


### PR DESCRIPTION
First step for #9

Will add GH Actions and output 2 DMGs (Intel/ARM) with the JDKs embedded per default and some GitHub Releases so people can download the latest Ghidra and have it working out of the box.